### PR TITLE
feat: add debug page for environment variables

### DIFF
--- a/app/api/env-debug/route.ts
+++ b/app/api/env-debug/route.ts
@@ -78,6 +78,7 @@ export async function GET() {
           : "INVALID"
         : "MISSING",
       XAI_API_KEY: envVars.XAI_API_KEY ? "SET" : "MISSING",
+      STRIPE_WEBHOOK_SECRET: process.env.STRIPE_WEBHOOK_SECRET ? "SET" : "MISSING",
     },
     recommendations: [],
   }


### PR DESCRIPTION
This commit adds a new page at `/api/env-debug` to display the status of environment variables. This will help in debugging the Stripe webhook issue.